### PR TITLE
Permit use proxy server with vagrant-proxyconf plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ For now the default box is the `fgrehm/trusty64-lxc` box which is reasonably out
 
 1. [vagrant-lxc](https://github.com/fgrehm/vagrant-lxc)
 2. [salty-vagrant-grains](https://github.com/ahmadsherif/salty-vagrant-grains) (optional)
+3. [vagrant-proxyconf](https://github.com/tmatilai/vagrant-proxyconf) (optional)
 
 If installed the vagrant-salty-grains plugin will be used for creating grains on the minions and devmaster.
+If installed the vagrant-proxyconf plugin will be used to configures the virtual machine to use proxies
 
 ## Quickstart
 
@@ -64,6 +66,7 @@ All global settings are stored under the `settings` key, some can be overidden o
 | `default_box_url` | Default box URL | |
 | `network` | Network to use for vagrant (/24), without last octect | 10.0.3 |
 | `bridge` | Network bridge device to use | 'lxcbr0' |
+| `proxy` | Proxy server to use | |
 
 #### Example
 
@@ -71,6 +74,7 @@ All global settings are stored under the `settings` key, some can be overidden o
 settings:
   default_box: fgrehm/trusty64-lxc
   network: 10.66.6
+  proxy: http://192.168.0.2:3128
 ```
 
 ### Master Settings

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -36,6 +36,7 @@ domain          = ".#{settings['domain']}"    || ''
 default_box     = settings['default_box']     || 'fgrehm/trusty64-lxc'
 network         = settings['network']         || '10.0.3'
 bridge          = settings['brigde']          || 'lxcbr0'
+proxy		= settings['proxy']           || ''
 master_box      = master['box']               || default_box
 master_box_url  = master['box_url']           || false
 master_grains   = master['grains']            || {}
@@ -68,6 +69,13 @@ minion_config = default_minion_config.merge!(minion_config)
 
 # Create boxes
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # Configure proxy
+  if Vagrant.has_plugin?("vagrant-proxyconf")
+    config.proxy.http     = "#{proxy}"
+    config.proxy.https    = "#{proxy}"
+    config.proxy.no_proxy = "localhost,127.0.0.1,.#{domain}"
+  end
+
   # Create Salt Master
   config.vm.define 'devmaster' do |master|
     master.vm.provider :lxc do |lxc|


### PR DESCRIPTION
Use "Proxy Configuration Plugin for Vagrant" in order to configures the virtual machine to use specified proxy server. This is useful for example in case you are behind a corporate proxy server, or you have a caching proxy.

This pull request updates the Readme file for some explanations.