### PR TITLE
Add install_args parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ All global settings are stored under the `settings` key, some can be overidden o
 | Key | Use | Default Value |
 | --- | --- | ------------- |
 | `salt_version` | Set version of salt to use/install | stable |
+| `install_args` | When performing a git install, you can specify a branch, tag, or any treeish. Not supported on Windows. | |
 | `domain` | Appended to the end of minion names | |
 | `default_box` | Default box to use for minions | fgrehm/trusty64-lxc |
 | `default_box_url` | Default box URL | |
@@ -71,6 +72,8 @@ All global settings are stored under the `settings` key, some can be overidden o
 settings:
   default_box: fgrehm/trusty64-lxc
   network: 10.66.6
+  salt_version: git
+  install_args: 2016.11.7
 ```
 
 ### Master Settings

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,6 +32,7 @@ minions         = config['minions']           || []
 
 # Set options from config, use defaults if they don't exist
 salt_version    = settings['salt_version']    || 'stable'
+install_args    = settings['install_args']    || ''
 domain          = ".#{settings['domain']}"    || ''
 default_box     = settings['default_box']     || 'fgrehm/trusty64-lxc'
 network         = settings['network']         || '10.0.3'
@@ -88,6 +89,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     master.vm.provision :salt do |salt|
       salt.minion_id         = 'devmaster'
       salt.install_type      = salt_version
+      salt.install_args      = install_args
       salt.install_master    = true
       salt.bootstrap_options = "-J '#{master_config.to_json}' -j '{\"master\": \"localhost\"}'"
       salt.run_highstate     = false
@@ -140,6 +142,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       minion.vm.provision :salt do |salt|
         salt.minion_id         = name
         salt.install_type      = salt_version
+        salt.install_args      = install_args
         salt.bootstrap_options = "-j '#{minion_config.to_json}'"
         salt.run_highstate     = highstate
         salt.verbose           = false


### PR DESCRIPTION
 Add install_args parameter. When performing a git install, you can specify a branch, tag, or any treeish. Not supported on Windows.

This pull request updates the Readme file for some explanations.